### PR TITLE
Fix malformed embed tag in teaching page

### DIFF
--- a/teaching.html
+++ b/teaching.html
@@ -61,7 +61,7 @@ Station.
       width="100%"
       height="850px"
       style="border:1px solid #ccc; box-shadow:0 0 8px rgba(0,0,0,.1);"
-    embed>
+    />
 
   </main>
 </body>


### PR DESCRIPTION
## Summary
- Correct malformed `<embed>` tag on teaching page for syllabus PDF

## Testing
- `npx htmlhint *.html`


------
https://chatgpt.com/codex/tasks/task_e_6895170928008326a8b58dcb7f53d169