### PR TITLE
Fix duplicate word in teaching note

### DIFF
--- a/teaching.html
+++ b/teaching.html
@@ -49,7 +49,7 @@ Station.
     </ul>
 
     <p><em>
-      Note: the title of this course has been tweaked several times, and was offered as: "Politics of Spaceflight," "Spaceflight History," "International Relations of Spaceflight," "International Relations as a function of of Spaceflight," "Spaceflight Politics."
+      Note: the title of this course has been tweaked several times, and was offered as: "Politics of Spaceflight," "Spaceflight History," "International Relations of Spaceflight," "International Relations as a function of Spaceflight," "Spaceflight Politics."
     </em></p>
 
     <h2>Course Syllabus</h2>


### PR DESCRIPTION
## Summary
- remove duplicated "of" in teaching course title note

## Testing
- `w3m -dump teaching.html | sed -n '20,40p'`


------
https://chatgpt.com/codex/tasks/task_e_689518807cd48326b89f5163c5dee064