### PR TITLE
Add navbar test and fix projects page

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest beautifulsoup4
+      - name: Run tests
+        run: pytest

--- a/projects.html
+++ b/projects.html
@@ -1,8 +1,25 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <title>Title</title>
-    </head>
-    <body></body>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Projects</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <nav>
+      <ul class="navbar">
+        <li><a href="index.html"        class="nav-about">About me</a></li>
+        <li><a href="publications.html" class="nav-pubs">Publications</a></li>
+        <li><a href="teaching.html"     class="nav-teaching">Teaching</a></li>
+        <li><a href="projects.html"        class="nav-projects">Projects</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main style="padding:2em; max-width:800px; margin:auto;">
+    <h1>Projects</h1>
+    <p>More information about my projects will be added soon.</p>
+  </main>
+</body>
 </html>

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -1,0 +1,15 @@
+import glob
+from bs4 import BeautifulSoup
+
+
+def test_navbar_links():
+    html_files = glob.glob('*.html')
+    expected_classes = ['nav-about', 'nav-pubs', 'nav-teaching', 'nav-projects']
+    for html_file in html_files:
+        with open(html_file, 'r', encoding='utf-8') as f:
+            soup = BeautifulSoup(f, 'html.parser')
+        navbar = soup.find('ul', class_='navbar')
+        assert navbar is not None, f"{html_file} missing <ul class='navbar'>"
+        link_classes = {cls for a in navbar.find_all('a') for cls in (a.get('class') or [])}
+        for expected in expected_classes:
+            assert expected in link_classes, f"{html_file} missing link class {expected}"


### PR DESCRIPTION
## Summary
- add regression test to verify all HTML pages include full navbar
- fix projects.html to include navbar and placeholder content
- add GitHub Actions workflow to run pytest

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68951886639c83269ea33b571c09cd2c